### PR TITLE
fix: changed media query grid so cards don't break at certain screen …

### DIFF
--- a/Frontend/my-react-app/src/pages/CompletedProjects.css
+++ b/Frontend/my-react-app/src/pages/CompletedProjects.css
@@ -86,3 +86,14 @@
         margin-bottom: 18vh;
     }
 }
+
+@media(max-width: 1000px){
+    .completedProjectContainer {
+        display: grid;
+        grid-template-columns: repeat(2, 45%);
+        gap: 50px;
+        padding: 10px;
+        justify-content: center;
+        padding-bottom: 50px;
+    }
+}


### PR DESCRIPTION
…size

**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes
_List Changes Introduced by this PR_
1. Created a query to target specific screen size so cards would not break

## Purpose
Stopped the cards from wrapping and overflowing

## Approach
Makes page look more professional.

## Pre-Testing TODOs

## Testing Steps

## Learning


_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #263 
