### PR TITLE
Updated interns mobile responsiveness(updated restyle set for later)

### DIFF
--- a/Frontend/migration-vite/src/App.css
+++ b/Frontend/migration-vite/src/App.css
@@ -64,3 +64,9 @@
   width: 5vh;
   filter: invert(1);
 }
+
+@media (max-width: 768px){
+  .fab{
+    display: none;
+  }
+}

--- a/Frontend/migration-vite/src/components/MobileNav/MobileNav.css
+++ b/Frontend/migration-vite/src/components/MobileNav/MobileNav.css
@@ -1,7 +1,7 @@
 /* BottomNav.css */
 .bottom-nav {
   position: fixed;
-  bottom: 20%;
+  bottom: 0;
   height: 60px;
   background: #212121;
   display: flex;

--- a/Frontend/migration-vite/src/pages/Interns.css
+++ b/Frontend/migration-vite/src/pages/Interns.css
@@ -258,22 +258,105 @@
 }
 /* Responsive Design */
 @media (max-width: 768px) {
-  .content {
-      flex-direction: column; 
-      align-items: center;
+  .container{
+    padding: 0 20px 20px;
   }
-  .search-bar-wrapper{
-  display: flex;
-  justify-content: center;    
+
+  .content{
+    display: flex;
+    flex-direction: column;
+    gap: 0;
   }
-  .filtering-wrapper,
-  .interns-wrapper {
-    justify-content: center ;
-      width: 90%; 
-      max-width: none; 
+
+  .mobileFilterDiv{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .filtering-wrapper {
+    display: none;
+  }
+  
+  .filtering-wrapper h3, .filtering-wrapper label{
+    margin-bottom: 10px;
+  }
+
+  .filtering-wrapper.show {
+    display: block;
+    width: 100%;
+    margin-top: 10px;
+  }
+
+  .search-bar-wrapper, .filtering-wrapper select{
+    margin-bottom: 30px;
+  }
+
+  .mobile-filter-toggle {
+    background: linear-gradient(to right, #ec4899, #a655f1);
+    color: white;
+    padding: 15px 35px;
+    border: none;
+    border-radius: 30px;
+    font-size: 18px;
+    margin: 20px 0;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .filtering-wrapper h3{
+    font-size: 16px;
+  }
+
+  .mobileFilterDiv h1{
+    font-size: 2.4rem;
+  }
+
+  .mobile-filter-toggle:hover {
+    background: linear-gradient(to right, #2dd4bf, #3b82f6);
+  }
+
+  .select-buttons{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .select-btn, .deselect-btn, .delete-selected-btn{
+    border-radius: 30px;
+    font-weight: 700;
+    font-size: 18px;
+    padding: 15px 20px;
+  }
+
+  .delete-selected-btn:disabled{
+    background-color: grey;
+    border-radius: 30px;
+    font-weight: 700;
+  }
+
+  .interns-wrapper{
+    padding-bottom: 80px;
+    background: transparent;
+    margin: 0;
+    padding-left: 0;
+    border: none;
+    padding-right: 0;
+    box-shadow: none;
+  }
+
+  .interns-wrapper h2{
+    display: none;
   }
 
   .interns-wrapper ul li {
-      width: 95%; 
+    border-radius: 10px;
+    padding: 20px;
+  }
+
+  .intern-container{
+    padding: 0% 10px;
+    margin-top: 18%;
   }
 }

--- a/Frontend/migration-vite/src/pages/Interns.jsx
+++ b/Frontend/migration-vite/src/pages/Interns.jsx
@@ -29,6 +29,8 @@ const Interns = () => {
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [deleteType, setDeleteType] = useState(""); // "single" or "bulk"
   const [error, setError] = useState(null);
+  const [showMobileFilters, setShowMobileFilters] = useState(false);
+
 
   const filterInterns = useRef([]);
   const navigate = useNavigate();
@@ -246,7 +248,19 @@ const Interns = () => {
       {error && <div className="error-message">{error}</div>}
       <div className="container">
         <div className="content">
-          <div className="filtering-wrapper">
+        {window.innerWidth <= 768 && (
+          <div className="mobileFilterDiv">
+            <h1>Interns</h1>
+            <button
+              className="mobile-filter-toggle"
+              onClick={() => setShowMobileFilters(!showMobileFilters)}
+            >
+              {showMobileFilters ? "Hide Filters" : "Show Filters"}
+            </button>
+          </div>
+            
+          )}
+          <div className={`filtering-wrapper ${showMobileFilters ? "show" : ""}`}>
             <h3 className="filter-header">Filter Interns</h3>
             <div className="search-bar-wrapper">
               <SearchBar onSearch={handleSearch} />
@@ -262,14 +276,20 @@ const Interns = () => {
 
           <div className="interns-wrapper">
             <div className="select-buttons">
-              <div className="select-left">
-                <button className="select-btn" onClick={handleSelectAll}>
-                  Select All
-                </button>
-                <button className="deselect-btn" onClick={handleDeselectAll}>
-                  Deselect All
-                </button>
-              </div>
+            <div className="select-left">
+              <button
+                className="select-btn"
+                onClick={
+                  selectedInterns.length === filteredInterns.length
+                    ? handleDeselectAll
+                    : handleSelectAll
+                }
+              >
+                {selectedInterns.length === filteredInterns.length
+                  ? "Deselect All"
+                  : "Select All"}
+              </button>
+            </div>
               <div className="delete-right">
                 <button
                   className="delete-selected-btn"


### PR DESCRIPTION
**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes
_List Changes Introduced by this PR_
1. Updated the navigation bar on the bottom to be set up properly
2. Fixed how the buttons were originally structured
3. Updated the button from having 2 buttons (select, deselect) to just one button that toggles between each other
4. Filter button toggles when clicked so it takes less screen room

## Purpose
Current styling was bad by having a lot of buttons squished together and filter div taking a good chunk of mobile screen
<img width="332" alt="Screenshot 2025-05-13 at 10 53 02 AM" src="https://github.com/user-attachments/assets/24c585c5-993e-42d0-a464-7ba8660d1a38" />

## Approach
Makes it to that the new styling requires less space and less buttons in general. Does not look so crampped
<img width="321" alt="Screenshot 2025-05-13 at 10 55 13 AM" src="https://github.com/user-attachments/assets/4da0fe0d-f928-41a8-aa38-6c095d73e3b0" />

## Pre-Testing TODOs

## Testing Steps

## Learning

_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #327 
