### PR TITLE
Updated interns page so the trash bin icon is replaced by growth icon

### DIFF
--- a/Frontend/migration-vite/src/pages/EditIntern.css
+++ b/Frontend/migration-vite/src/pages/EditIntern.css
@@ -59,30 +59,6 @@
     }
 }
 
-/* Growth Button */
-.growth-button {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: linear-gradient(to right, #2dd4bf, #3b82f6);
-  border: none;
-  border-radius: 25px;
-  padding: 8px 16px;
-  cursor: pointer;
-  color: white;
-  font-size: 14px;
-  font-weight: bold;
-    &:hover{
-      scale: 1.05;
-    }
-}
-
-.growth-button img{
-  filter: invert(1);
-}
-
-
-
 .updateNameContainer, .updateLocationDepartmentContainer{
   display: flex;
   justify-content: space-between;

--- a/Frontend/migration-vite/src/pages/EditIntern.jsx
+++ b/Frontend/migration-vite/src/pages/EditIntern.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import NavBar from "../components/Navbar/NavBar"; // Import the NavBar component
-import growth from "../assets/growth.svg";
 import returnArrow from "../assets/returnArrow.svg";
 import './EditIntern.css';
 
@@ -154,16 +153,6 @@ const EditIntern = () => {
           <div className="editInternHeaderWrapper">
             <button className="back-button" onClick={handleBack}>
               <img src={returnArrow} alt="Back" />
-            </button>
-            <button 
-              className="growth-button" 
-              onClick={(e) => { 
-                e.stopPropagation(); 
-                navigate(`/internGrowthPage/${internID}`); 
-              }}
-            >
-              <img src={growth} alt="growth" />
-              <span>Intern Growth</span>
             </button>
           </div>
           <h2 className="editInternHeader">Edit Intern</h2>

--- a/Frontend/migration-vite/src/pages/InternGrowthPage.jsx
+++ b/Frontend/migration-vite/src/pages/InternGrowthPage.jsx
@@ -49,7 +49,7 @@ const InternGrowthPage = () => {
             <div className="intern-growth-page">
                 <div className="header-container">
                     {/* Back Button */}
-                    <button className="returnToProjects" onClick={() => navigate(`/editIntern/${internID}`)}>
+                    <button className="returnToProjects" onClick={() => navigate(`/interns`)}>
                         <img className="returnArrow" src={returnArrow} alt="Return to Projects" />
                     </button>
 

--- a/Frontend/migration-vite/src/pages/Interns.css
+++ b/Frontend/migration-vite/src/pages/Interns.css
@@ -43,6 +43,28 @@
   max-height: calc(100vh - 200px); /* Adjust based on layout */
 }
 
+/* Growth Button */
+.growth-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: 2px solid;
+  border-radius: 25px;
+  padding: 8px 16px;
+  cursor: pointer;
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+    &:hover{
+      scale: 1.05;
+    }
+}
+
+.growth-button img{
+  filter: invert(1);
+}
+
 /* Prevents filtering and buttons from shrinking */
 .filtering-wrapper, .select-buttons {
   flex-shrink: 0;
@@ -216,6 +238,7 @@
 .interns-wrapper ul li .icon-container {
   display: flex;
   gap: 10px;
+  align-items: center;
 }
 
 .interns-wrapper ul li img.edit,
@@ -224,6 +247,9 @@
   width: 25px;
   cursor: pointer;
   filter: brightness(0) invert(1); /* Makes the image white */
+  &:hover{
+    scale: 1.15;
+  }
 }
 
 .profile-pic {

--- a/Frontend/migration-vite/src/pages/Interns.jsx
+++ b/Frontend/migration-vite/src/pages/Interns.jsx
@@ -5,8 +5,8 @@ import SearchBar from "../components/SearchBar/SearchBar";
 import Filtering from "../components/Filtering/Filtering";
 import ConfirmPopup from "../components/ConfirmPopup/ConfirmPopup";
 import edit from "../assets/edit.svg";
-import del from "../assets/delete.svg";
 import profile from "../assets/profile.svg";
+import growth from "../assets/growth.svg";
 import "./Interns.css";
 
 // Cache expiration time (1 hour)
@@ -336,15 +336,15 @@ const Interns = () => {
                           navigate(`/editIntern/${intern.InternID}`);
                         }}
                       />
-                      <img
-                        src={del}
-                        alt="delete"
-                        className="delete"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          confirmDelete(intern.InternID, "single");
+                      <button 
+                        className="growth-button" 
+                        onClick={(e) => { 
+                          e.stopPropagation(); 
+                          navigate(`/internGrowthPage/${intern.InternID}`); 
                         }}
-                      />
+                      >
+                        <img src={growth} alt="growth" />
+                      </button>
                     </div>
                   </li>
                 ))}


### PR DESCRIPTION
**When you open your pull requests, remove the lines that start and end with underscores (\_)**

## Changes
_List Changes Introduced by this PR_
1. Removed growth button from edit interns page since we it was hidden there
2. Updated interns row from having an edit button and trash icon to an edit button and growth button

## Purpose
Issue was that if user wanted to see their growth they would have to go down a level into a page that they would most likely not use causing the button to be hidden unless users knew about it or found it accidentally.
<img width="1440" alt="Screenshot 2025-05-13 at 11 51 53 AM" src="https://github.com/user-attachments/assets/1f9adf24-2c97-49cb-a3a3-455f8e754a11" />

## Approach
Removed the button and placed it in one of the main pages for easier access
<img width="1440" alt="Screenshot 2025-05-13 at 11 52 49 AM" src="https://github.com/user-attachments/assets/07b4500f-aed1-461b-a010-e1d6f5267f78" />

## Pre-Testing TODOs

## Testing Steps

## Learning


_If this closes an issue, name it here. If it doesn't, remove this line_
Closes #333 
